### PR TITLE
3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tigeax.customwings</groupId>
     <artifactId>CustomWings</artifactId>
-    <version>3.6.4</version>
+    <version>3.7.0</version>
     <packaging>jar</packaging>
 
     <name>CustomWings</name>

--- a/src/main/java/tigeax/customwings/CWPlayer.java
+++ b/src/main/java/tigeax/customwings/CWPlayer.java
@@ -2,6 +2,8 @@ package tigeax.customwings;
 
 import java.time.Instant;
 import java.util.UUID;
+
+import org.bukkit.Location;
 import tigeax.customwings.editor.SettingType;
 import tigeax.customwings.gui.CWGUIManager;
 import tigeax.customwings.gui.CWGUIType;
@@ -9,6 +11,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
+import tigeax.customwings.nms.NMSSupport;
 import tigeax.customwings.wings.Wing;
 
 /*
@@ -28,6 +31,9 @@ public class CWPlayer {
 	private SettingType waitingSetting;
 	private Object waitingSettingInfo;
 	private InventoryView lastEditorInvView;
+
+	private boolean previewingWing = false;
+	private Location wingPreviewLocation = null;
 
 	private long lastMove;
 
@@ -50,6 +56,25 @@ public class CWPlayer {
 	public Player getPlayer() { return Bukkit.getPlayer(uuid); }
 	
 	public Wing getEquippedWing() { return equippedWing; }
+
+	public boolean isPreviewingWing() {
+		return (wingPreviewLocation != null);
+	}
+
+	public void setPreviewingWing(boolean previewing) {
+
+		if (previewing) {
+			Location loc = getPlayer().getLocation();
+			loc.setYaw(NMSSupport.getBodyRotation(getPlayer()));
+			wingPreviewLocation = loc;
+		} else {
+			wingPreviewLocation = null;
+		}
+	}
+
+	public Location getPreviewWingLocation() {
+		return wingPreviewLocation;
+	}
 
 	public boolean getHideOtherPlayerWings() { return hideOtherPlayerWings; }
 	
@@ -104,7 +129,7 @@ public class CWPlayer {
 
 		// Remove the player from the old wing
 		if (this.equippedWing != null) {
-			this.equippedWing.removeFromPreview(getPlayer());
+			setPreviewingWing(false); // Disable preview
 			this.equippedWing.removePlayersWithWingActive(getPlayer());
 		}
 

--- a/src/main/java/tigeax/customwings/CWPlayer.java
+++ b/src/main/java/tigeax/customwings/CWPlayer.java
@@ -90,13 +90,11 @@ public class CWPlayer {
 	public InventoryView getLastEditorInvView() { return lastEditorInvView; }
 	public void setLastEditorInvView(InventoryView invView) { this.lastEditorInvView = invView; }
 
+	// Calculate if the player is currently moving, based on when the player was last detected as moving
 	public boolean isMoving() {
 		Instant instant = Instant.now();
 		long now = instant.getEpochSecond();
-		long milli = instant.getNano();
-		now *= 1000000000L;
-		now += milli;
-		return now < lastMove+20000000;
+		return this.lastMove >= (now - 1);
 	}
 	
 	public SettingType getWaitingSetting() { return waitingSetting; }
@@ -141,7 +139,8 @@ public class CWPlayer {
 
 	}
 
-	public void setMoving(long moveTimestamp) {
+	//Set the time when the player was last counted at moving
+	public void setLastTimeMoving(long moveTimestamp) {
 		this.lastMove = moveTimestamp;
 	}
 	

--- a/src/main/java/tigeax/customwings/command/Wings.java
+++ b/src/main/java/tigeax/customwings/command/Wings.java
@@ -146,14 +146,10 @@ public class Wings implements CommandExecutor {
 			player.sendMessage(CustomWings.getMessages().getNoWingToPreview());
 			return;
 		}
-		
-		// If the player is already previewing a wing stop previewing
-		if (cwPlayer.getEquippedWing().isPreviewing(player)) {
-			wing.removeFromPreview(player);
-			return;
-		}
 
-		wing.addToPreview(player);
+		// Toggle the wing previewing
+		cwPlayer.setPreviewingWing(cwPlayer.isPreviewingWing());
+
 	}
 
 	// Open the editor GUI

--- a/src/main/java/tigeax/customwings/command/Wings.java
+++ b/src/main/java/tigeax/customwings/command/Wings.java
@@ -148,8 +148,7 @@ public class Wings implements CommandExecutor {
 		}
 
 		// Toggle the wing previewing
-		cwPlayer.setPreviewingWing(cwPlayer.isPreviewingWing());
-
+		cwPlayer.setPreviewingWing(!cwPlayer.isPreviewingWing());
 	}
 
 	// Open the editor GUI

--- a/src/main/java/tigeax/customwings/eventlisteners/InventoryClickEventListener.java
+++ b/src/main/java/tigeax/customwings/eventlisteners/InventoryClickEventListener.java
@@ -65,7 +65,7 @@ public class InventoryClickEventListener implements Listener {
 		
 		int clickedItemSlot = event.getSlot();
 
-		// Check if the clicked inventory is the CustomWings GUI
+		// Check if the clicked inventory is a CustomWings GUI
 		if (inventoryTitle.equals(CustomWings.getSettings().getMainGUIName())
 				|| inventoryTitle.contains(CustomWings.getSettings().getEditorGUIName())) {
 			
@@ -75,13 +75,17 @@ public class InventoryClickEventListener implements Listener {
 
 			if (clickedItem.getItemMeta() == null) { return; }
 
-			CWGUIType CWGUIType = CustomWings.getCWGUIManager().getCWGUITypeByInvTitle(inventoryTitle);
+			CWGUIType cwGUIType = CustomWings.getCWGUIManager().getCWGUITypeByInvTitle(inventoryTitle);
 
-			PlayerCWGUIClickEvent playerCWGUIClickEvent = new PlayerCWGUIClickEvent(cwPlayer, CWGUIType, event.getView(), clickedItem, clickedItemSlot);
+			if (cwGUIType == null) {
+				return;
+			}
+
+			PlayerCWGUIClickEvent playerCWGUIClickEvent = new PlayerCWGUIClickEvent(cwPlayer, cwGUIType, event.getView(), clickedItem, clickedItemSlot);
 			Bukkit.getServer().getPluginManager().callEvent(playerCWGUIClickEvent);
 
 			if (!playerCWGUIClickEvent.isCancelled()) {
-				CustomWings.getCWGUIManager().CWGUIClick(cwPlayer, CWGUIType, event.getView(), clickedItem, clickedItemSlot);
+				CustomWings.getCWGUIManager().CWGUIClick(cwPlayer, cwGUIType, event.getView(), clickedItem, clickedItemSlot);
 			}
 
 		}

--- a/src/main/java/tigeax/customwings/eventlisteners/InventoryCloseEventListener.java
+++ b/src/main/java/tigeax/customwings/eventlisteners/InventoryCloseEventListener.java
@@ -25,7 +25,8 @@ public class InventoryCloseEventListener implements Listener {
 
 			CWGUIType cwGUIType = CustomWings.getCWGUIManager().getCWGUITypeByInvTitle(inventoryTitle);
 
-			if (cwGUIType == CWGUIType.EDITORSELECTDOUBLE 
+			if (cwGUIType == null
+					|| cwGUIType == CWGUIType.EDITORSELECTDOUBLE
 					|| cwGUIType == CWGUIType.EDITORSELECTGUISIZE
 					|| cwGUIType == CWGUIType.EDITORSELECTINTEGER
 					|| cwGUIType == CWGUIType.EDITORSELECTPARTICLE

--- a/src/main/java/tigeax/customwings/eventlisteners/PlayerMoveListener.java
+++ b/src/main/java/tigeax/customwings/eventlisteners/PlayerMoveListener.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import tigeax.customwings.CWPlayer;
 import tigeax.customwings.CustomWings;
 import tigeax.customwings.nms.NMSSupport;
 import java.time.Instant;
@@ -15,22 +16,19 @@ public class PlayerMoveListener implements Listener {
     public void onMoveEvent(org.bukkit.event.player.PlayerMoveEvent event) {
 
         Bukkit.getScheduler().runTaskAsynchronously(CustomWings.getPlugin(CustomWings.class), () -> {
-            long now = Instant.now().getEpochSecond();
+
             Player player = event.getPlayer();
-            if (event.getFrom().getX() != event.getTo().getX()) {
-                NMSSupport.setBodyRotation(player, player.getLocation().getYaw());
-                CustomWings.getCWPlayer(player).setMoving(now);
+            CWPlayer cwPlayer = CustomWings.getCWPlayer(player);
+
+            if (cwPlayer.getEquippedWing() == null) {
                 return;
             }
-            if (event.getFrom().getZ() != event.getTo().getZ()) {
+
+            long now = Instant.now().getEpochSecond();
+
+            if (event.getFrom().distance(event.getTo()) > 0.2) {
                 NMSSupport.setBodyRotation(player, player.getLocation().getYaw());
-                CustomWings.getCWPlayer(player).setMoving(now);
-                return;
-            }
-            if (event.getFrom().getY() != event.getTo().getY()) {
-                NMSSupport.setBodyRotation(player, player.getLocation().getYaw());
-                CustomWings.getCWPlayer(player).setMoving(now);
-                return;
+                CustomWings.getCWPlayer(player).setLastTimeMoving(now);
             }
         });
 

--- a/src/main/java/tigeax/customwings/eventlisteners/PlayerQuitEventListener.java
+++ b/src/main/java/tigeax/customwings/eventlisteners/PlayerQuitEventListener.java
@@ -26,7 +26,6 @@ public class PlayerQuitEventListener implements Listener {
 
 		if (cwPlayer.getEquippedWing() != null) {
 			cwPlayer.getEquippedWing().removePlayersWithWingActive(player);
-			cwPlayer.getEquippedWing().removeFromPreview(player);
 			cwPlayer.setWaitingSetting(null);
 		}
 	}

--- a/src/main/java/tigeax/customwings/gui/CWGUIManager.java
+++ b/src/main/java/tigeax/customwings/gui/CWGUIManager.java
@@ -62,43 +62,50 @@ public class CWGUIManager {
 	}
 
 	public void openGUI(CWPlayer cwPlayer, CWGUIType cwGUIType, Object info) {
-		switch (cwGUIType) {
-			case WINGSELECT:
-				wingSelectGUI.open(cwPlayer, 0);
-				return;
-			case EDITOR:
-				editorGUI.open(cwPlayer);
-				return;
-			case EDITORMAINSETTINGS:
-				editorMainSettingsGUI.open(cwPlayer);
-				return;
-			case EDITORWINGSETTINGS:
-				editorWingSettingsGUI.open(cwPlayer, (Wing) info);
-				return;
-			case EDITORWINGPARITCLESSELECT:
-				editorWingParticlesSelectGUI.open(cwPlayer, (Wing) info);
-				return;
-			case EDITORWINGPARTICLESETTINGS:
-				editorWingParticleSettingsGUI.open(cwPlayer, (WingParticle) info);
-				return;
-			case EDITORSELECTGUISIZE:
-				editorSelectGuiSizeGUI.open(cwPlayer);
-				return;
-			case EDITORSELECTPARTICLE:
-				editorSelectParticleGUI.openPage1(cwPlayer);
-				return;
-			case EDITORSELECTSLOT:
-				editorSelectSlotGUI.open(cwPlayer);
-				return;
-			case EDITORSELECTINTEGER:
-				editorSelectIntegerGUI.open(cwPlayer, (Integer) info);
-				return;
-			case EDITORSELECTDOUBLE:
-				editorSelectDoubleGUI.open(cwPlayer, (double) info);
-				return;
-			case LASTEDITORGUI:
-				openLastEditorGUI(cwPlayer);
-				return;
+		try {
+
+			switch (cwGUIType) {
+				case WINGSELECT:
+					wingSelectGUI.open(cwPlayer, 0);
+					return;
+				case EDITOR:
+					editorGUI.open(cwPlayer);
+					return;
+				case EDITORMAINSETTINGS:
+					editorMainSettingsGUI.open(cwPlayer);
+					return;
+				case EDITORWINGSETTINGS:
+					editorWingSettingsGUI.open(cwPlayer, (Wing) info);
+					return;
+				case EDITORWINGPARITCLESSELECT:
+					editorWingParticlesSelectGUI.open(cwPlayer, (Wing) info);
+					return;
+				case EDITORWINGPARTICLESETTINGS:
+					editorWingParticleSettingsGUI.open(cwPlayer, (WingParticle) info);
+					return;
+				case EDITORSELECTGUISIZE:
+					editorSelectGuiSizeGUI.open(cwPlayer);
+					return;
+				case EDITORSELECTPARTICLE:
+					editorSelectParticleGUI.openPage1(cwPlayer);
+					return;
+				case EDITORSELECTSLOT:
+					editorSelectSlotGUI.open(cwPlayer);
+					return;
+				case EDITORSELECTINTEGER:
+					editorSelectIntegerGUI.open(cwPlayer, (Integer) info);
+					return;
+				case EDITORSELECTDOUBLE:
+					editorSelectDoubleGUI.open(cwPlayer, (double) info);
+					return;
+				case LASTEDITORGUI:
+					openLastEditorGUI(cwPlayer);
+					return;
+			}
+
+		} catch (Exception e) {
+			System.out.println(e);
+			cwPlayer.openCWGUI(CWGUIType.EDITOR);
 		}
 	}
 
@@ -121,15 +128,16 @@ public class CWGUIManager {
 				return CWGUIType.EDITORWINGPARTICLESETTINGS;
 			case "Main GUI Size":
 				return CWGUIType.EDITORSELECTGUISIZE;
+			case "Select Particle":
+				return CWGUIType.EDITORSELECTPARTICLE;
 			case "Select Slot":
 				return CWGUIType.EDITORSELECTSLOT;
 			case "Set Integer":
 				return CWGUIType.EDITORSELECTINTEGER;
 			case "Set Double":
 				return CWGUIType.EDITORSELECTDOUBLE;
-			case "Select Particle":
-				return CWGUIType.EDITORSELECTPARTICLE;
 		}
+		System.out.println("Could not find CW GUI - If you see this please let the CustomWings developer know");
 		return null;
 	}
 
@@ -192,22 +200,29 @@ public class CWGUIManager {
 			return;
 		}
 
-		switch (getCWGUITypeByInvTitle(lastInvView.getTitle())) {
+		try {
 
-			case EDITORMAINSETTINGS:
-				cwPlayer.openCWGUI(CWGUIType.EDITORMAINSETTINGS);
-				return;
-			case EDITORWINGSETTINGS:
-				cwPlayer.openCWGUI(CWGUIType.EDITORWINGSETTINGS, getWingFromGUI(lastInvView));
-				return;
-			case EDITORWINGPARITCLESSELECT:
-				cwPlayer.openCWGUI(CWGUIType.EDITORWINGPARITCLESSELECT, getWingFromGUI(lastInvView));
-				return;
-			case EDITORWINGPARTICLESETTINGS:
-				cwPlayer.openCWGUI(CWGUIType.EDITORWINGPARTICLESETTINGS, getWingParticleFromGUI(lastInvView));
-				return;
-			default:
-				cwPlayer.openCWGUI(CWGUIType.EDITOR);
+			switch (getCWGUITypeByInvTitle(lastInvView.getTitle())) {
+
+				case EDITORMAINSETTINGS:
+					cwPlayer.openCWGUI(CWGUIType.EDITORMAINSETTINGS);
+					return;
+				case EDITORWINGSETTINGS:
+					cwPlayer.openCWGUI(CWGUIType.EDITORWINGSETTINGS, getWingFromGUI(lastInvView));
+					return;
+				case EDITORWINGPARITCLESSELECT:
+					cwPlayer.openCWGUI(CWGUIType.EDITORWINGPARITCLESSELECT, getWingFromGUI(lastInvView));
+					return;
+				case EDITORWINGPARTICLESETTINGS:
+					cwPlayer.openCWGUI(CWGUIType.EDITORWINGPARTICLESETTINGS, getWingParticleFromGUI(lastInvView));
+					return;
+				default:
+					cwPlayer.openCWGUI(CWGUIType.EDITOR);
+			}
+
+		} catch (Exception e) {
+			System.out.println(e);
+			cwPlayer.openCWGUI(CWGUIType.EDITOR);
 		}
 	}
 

--- a/src/main/java/tigeax/customwings/gui/guis/EditorSelectParticle.java
+++ b/src/main/java/tigeax/customwings/gui/guis/EditorSelectParticle.java
@@ -96,7 +96,7 @@ public class EditorSelectParticle {
 			case "Next Page":
 				openPage2(cwPlayer);
 				return;
-			case "Previous page":
+			case "Previous Page":
 				openPage1(cwPlayer);
 				return;
 		}

--- a/src/main/java/tigeax/customwings/gui/guis/EditorWingParticlesSelect.java
+++ b/src/main/java/tigeax/customwings/gui/guis/EditorWingParticlesSelect.java
@@ -41,7 +41,7 @@ public class EditorWingParticlesSelect {
 
 	public void click(CWPlayer cwPlayer, String itemName, Wing wing) {
 
-		if (itemName.equals("Previous Page")) {
+		if (itemName.equals("Previous page")) {
 			cwPlayer.openCWGUI(CWGUIType.EDITORWINGSETTINGS, wing);
 			return;
 		}

--- a/src/main/java/tigeax/customwings/wings/Wing.java
+++ b/src/main/java/tigeax/customwings/wings/Wing.java
@@ -330,7 +330,7 @@ public class Wing {
 					if (wingOwner.isGliding()) continue;
 
 					Location playerLoc = wingOwner.getLocation();
-					ArrayList<Player> playersToShowWing = getPlayersWhoSeeWing(wingOwner, wingOwner.getLocation(), false);
+					ArrayList<Player> playersToShowWing = getPlayersWhoSeeWing(wingOwner, playerLoc, false);
 
 					spawnWing(playerLoc, wingOwner, playersToShowWing, offsetDegrees, false);
 
@@ -342,30 +342,35 @@ public class Wing {
 	// Spawn all the particles of the wing at a certain location for certain players
 	private void spawnWing(Location loc, Player owner, ArrayList<Player> showTo, float degreeOffset, Boolean previewWing) {
 
+		float yaw;
+		float yawLeft;
+		float yawRight;
+
+		if (previewWing) {
+			yawLeft = - degreeOffset;
+			yawRight = 180 + degreeOffset;
+		} else {
+			if (CustomWings.getCWPlayer(owner).isMoving()) {
+				yaw = loc.getYaw();
+				NMSSupport.setBodyRotation(owner, loc.getYaw());
+			} else {
+				yaw = NMSSupport.getBodyRotation(owner);
+			}
+			yawLeft = yaw - degreeOffset;
+			yawRight = yaw + 180 + degreeOffset;
+
+			// Shift wings down when player is sneaking
+			if (owner.isSneaking() && !owner.isFlying()) {
+				loc = loc.add(0, -0.25, 0);
+			}
+		}
+
 		// Loop through all the coordinates of the wing and spawn a particle for both the left and right part at that location
 		for (double[] coordinate : particleCoordinates.keySet()) {
 
 			WingParticle wingParticle = particleCoordinates.get(coordinate);
 			double distance = coordinate[0];
 			double height = coordinate[1];
-			float yaw;
-			float yawLeft;
-			float yawRight;
-
-			if (previewWing) {
-				yawLeft = - degreeOffset;
-				yawRight = 180 + degreeOffset;
-			}
-			else {
-				if (CustomWings.getCWPlayer(owner).isMoving()) {
-					yaw = loc.getYaw();
-					NMSSupport.setBodyRotation(owner, loc.getYaw());
-				} else {
-					yaw = NMSSupport.getBodyRotation(owner);
-				}
-				yawLeft = yaw - degreeOffset;
-				yawRight = yaw + 180 + degreeOffset;
-			}
 
 			Location particleLocLeft = getParticleSpawnLoc(loc, yawLeft, distance, height);
 			Location particleLocRight = getParticleSpawnLoc(loc, yawRight, distance, height);

--- a/src/main/java/tigeax/customwings/wings/Wing.java
+++ b/src/main/java/tigeax/customwings/wings/Wing.java
@@ -284,7 +284,7 @@ public class Wing {
 
 					// Check if the wing should be shown in this world
 					if (!getWhitelistedWorlds().contains("all")) {
-						if (!getWhitelistedWorlds().contains(wingOwner.getWorld().toString())) {
+						if (!getWhitelistedWorlds().contains(wingOwner.getWorld().getName())) {
 							continue;
 						}
 					}

--- a/src/main/java/tigeax/customwings/wings/WingParticle.java
+++ b/src/main/java/tigeax/customwings/wings/WingParticle.java
@@ -103,13 +103,10 @@ public class WingParticle {
 		for (Player player : players) {
 
 			// Shift wings down when player is sneaking
+			//TODO move this to the Wing class for better efficiency
 			if (owner.isSneaking() && !owner.isFlying() || owner.isGliding()) {
 				loc = loc.add(0, -0.25, 0);
 			}
-
-			// Stop rendering wings for player if they look down
-			if (player == owner && owner.getLocation().getPitch() > CustomWings.getSettings().getWingMaxPitch() && !owner.isGliding())
-				continue;
 
 			player.spawnParticle(particle, loc, 0, x, height, z, speed, particleData);
 		}

--- a/src/main/java/tigeax/customwings/wings/WingParticle.java
+++ b/src/main/java/tigeax/customwings/wings/WingParticle.java
@@ -102,12 +102,6 @@ public class WingParticle {
 		double z = Math.sin(yaw) * distance;
 		for (Player player : players) {
 
-			// Shift wings down when player is sneaking
-			//TODO move this to the Wing class for better efficiency
-			if (owner.isSneaking() && !owner.isFlying() || owner.isGliding()) {
-				loc = loc.add(0, -0.25, 0);
-			}
-
 			player.spawnParticle(particle, loc, 0, x, height, z, speed, particleData);
 		}
 	}

--- a/src/main/java/tigeax/customwings/wings/WingParticle.java
+++ b/src/main/java/tigeax/customwings/wings/WingParticle.java
@@ -84,24 +84,21 @@ public class WingParticle {
 	public Material getMaterialData() { return material; }
 
 	// Spawn the particle at a location for all players specified
-	// wingSide is used to caculate the data for particles that can have direction
-	public void spawnParticle(ArrayList<Player> players, Player owner, Location loc, String wingSide) {
+	// If the particle has velocity (defined by speed) we need to calculate the x and z values so the flies in the correct direction
+	// This direction is based on the yaw of the wing and the if the particle is part of the left or right side of the wing
+	// WingSide is a String of either 'left' or 'right'
+	public void spawnParticle(Location loc, ArrayList<Player> spawnForPlayers, Wing.WingSide wingSide) {
 
-		CWPlayer cwPlayer = CustomWings.getCWPlayer(owner);
-		float yaw;
-		if (cwPlayer.isMoving()) {
-			yaw = owner.getLocation().getYaw() - 90;
-		} else {
-			yaw = NMSSupport.getBodyRotation(owner) - 90;
-		}
+		double direction = loc.getYaw();
 
-		if (wingSide.equals("left")) yaw = (yaw + angle);
-		if (wingSide.equals("right")) yaw = (yaw - angle);
-		yaw = (float) (yaw * Math.PI) / 180;
-		double x = Math.cos(yaw) * distance;
-		double z = Math.sin(yaw) * distance;
-		for (Player player : players) {
+		if (wingSide == Wing.WingSide.LEFT) direction = (direction + angle);
+		if (wingSide == Wing.WingSide.RIGHT) direction = (direction - angle);
 
+		direction = Math.toRadians(direction);
+		double x = Math.cos(direction);
+		double z = Math.sin(direction);
+
+		for (Player player : spawnForPlayers) {
 			player.spawnParticle(particle, loc, 0, x, height, z, speed, particleData);
 		}
 	}


### PR DESCRIPTION
- Fixed wing preview rotation with player's body and fixed wings still showing for other players when the wingowner is in a vehicle, swimming, gliding ect.
- Moved wing offset when player is sneaker to Wing class and moved the yaw calculations to above the wing particleCoordinate loop, to avoid unnecessary extra repeating calculations
- Moved wing offset when player is sneaker to Wing class and moved the yaw calculations to above the wing particleCoordinate loop, to avoid unnecessary extra repeating calculations
- Made wing preview be in the same direction as the player when using the command. And cleanup in the Wings class
- Moved wing preview data to the CWPlayer class
- Fixed detection of when the player is moving
- Fixed the wing not getting shown in a whitelisted world, when 'all' is not used
- Fixed multiple issues with the editor GUI