### PR TITLE
Fix AOOBE when filling up main gui

### DIFF
--- a/src/main/java/tigeax/customwings/gui/guis/WingSelect.java
+++ b/src/main/java/tigeax/customwings/gui/guis/WingSelect.java
@@ -165,6 +165,9 @@ public class WingSelect {
             public void run() {
                 Inventory gui = cwPlayer.getPlayer().getOpenInventory().getTopInventory();
 
+                if (cwPlayer.getPlayer().getOpenInventory().getTitle().equals(settings.getMainGUIName()))
+                    return;
+
                 int limit = gui.getSize()-9;
                 int i = 0;
                 while (i <= limit) {
@@ -245,5 +248,4 @@ public class WingSelect {
             gui.setItem(settings.getHideWingsToggleSlot(), settings.getHideWingsToggleOFFItem());
         }
     }
-
 }


### PR DESCRIPTION
This fixes array out of bound exception when player somehow has other inventory open when gui fill action is executed async.
It's an outliar, but I've confirmed it happens in some cases