### PR TITLE
Correct "Previous Item" config

### DIFF
--- a/src/main/java/tigeax/customwings/menus/items/PreviousPageItem.java
+++ b/src/main/java/tigeax/customwings/menus/items/PreviousPageItem.java
@@ -9,7 +9,7 @@ public class PreviousPageItem extends MenuItem {
     public PreviousPageItem() {
         CustomWings plugin = CustomWings.getInstance();
         setDisplayName(plugin.getConfig().getNavigationPreviousItemName());
-        setMaterial(plugin.getConfig().getNavigationNextItemMaterial());
+        setMaterial(plugin.getConfig().getNavigationPreviousItemMaterial());
     }
 
     @Override


### PR DESCRIPTION
The code was falsly getting the next item material instead of the previous item material. **Unfortunately, I wasn't able to test the changed code yet, due to [this](https://gist.github.com/FuchsCrafter/aa8bbdf82477c3a282c84f3671f09258).**
_You can review the corrected version on the ["files changed" tab](https://github.com/Tigeax/CustomWings/pull/27/files)._
Please let me know if it works / doesnt work!